### PR TITLE
Adjust headline height for mobile

### DIFF
--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -1235,12 +1235,14 @@ input[type=submit].btn-white {
 	}
 	
 	
-	.headline {		
-	
-		.inner {			
-			padding-top:40px;
-			padding-bottom:40px;
-		}
+        .headline {
+                height:100vh;
+
+                .inner {
+                        height:100vh;
+                        padding-top:40px;
+                        padding-bottom:40px;
+                }
 	
 		.item-data {						
 	


### PR DESCRIPTION
## Summary
- make `.headline` fill the viewport on screens up to 1024px wide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68708e8e10108332924dbdb090ba8f0d